### PR TITLE
Update token JSON to use Tailwind CSS source colors

### DIFF
--- a/figma-tokens/$tokens.json
+++ b/figma-tokens/$tokens.json
@@ -24,19 +24,19 @@
             "type": "color"
           },
           "destructive": {
-            "value": "#dd5860",
+            "value": "#ef4444",
             "type": "color"
           },
           "success": {
-            "value": "#86d26f",
+            "value": "#22c55e",
             "type": "color"
           },
           "warning": {
-            "value": "#deb145",
+            "value": "#f59e0b",
             "type": "color"
           },
           "info": {
-            "value": "#4469c0",
+            "value": "#3b82f6",
             "type": "color"
           },
           "border": {
@@ -76,71 +76,71 @@
             "type": "color"
           },
           "red": {
-            "value": "#dd5860",
+            "value": "#ef4444",
             "type": "color"
           },
           "orange": {
-            "value": "#dc824d",
+            "value": "#f97316",
             "type": "color"
           },
           "amber": {
-            "value": "#deb145",
+            "value": "#f59e0b",
             "type": "color"
           },
           "yellow": {
-            "value": "#e5e04c",
+            "value": "#eab308",
             "type": "color"
           },
           "lime": {
-            "value": "#afd953",
+            "value": "#84cc16",
             "type": "color"
           },
           "green": {
-            "value": "#86d26f",
+            "value": "#22c55e",
             "type": "color"
           },
           "emerald": {
-            "value": "#76cd94",
+            "value": "#10b981",
             "type": "color"
           },
           "teal": {
-            "value": "#5b9ba8",
+            "value": "#14b8a6",
             "type": "color"
           },
           "cyan": {
-            "value": "#4469c0",
+            "value": "#06b6d4",
             "type": "color"
           },
           "sky": {
-            "value": "#373bda",
+            "value": "#0ea5e9",
             "type": "color"
           },
           "blue": {
-            "value": "#381ff4",
+            "value": "#3b82f6",
             "type": "color"
           },
           "indigo": {
-            "value": "#4b28e2",
+            "value": "#6366f1",
             "type": "color"
           },
           "violet": {
-            "value": "#6637d1",
+            "value": "#8b5cf6",
             "type": "color"
           },
           "purple": {
-            "value": "#844cc0",
+            "value": "#a855f7",
             "type": "color"
           },
           "fuchsia": {
-            "value": "#a361af",
+            "value": "#d946ef",
             "type": "color"
           },
           "pink": {
-            "value": "#c377a0",
+            "value": "#ec4899",
             "type": "color"
           },
           "rose": {
-            "value": "#e48e91",
+            "value": "#f43f5e",
             "type": "color"
           },
           "slate": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ivy-interactive/ivy-design-system",
-  "version": "1.1.12",
+  "version": "1.1.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ivy-interactive/ivy-design-system",
-      "version": "1.1.12",
+      "version": "1.1.22",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.0.3",
@@ -818,7 +818,6 @@
       "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -926,7 +925,6 @@
       "integrity": "sha512-oWtNM89Np+YsQO3ttT5i1Aer/0xbzQzp66NzuJn/U16bB7MnvSzdLKXgk1kkMLYyKSSzA2ajzqMkYheaE9opuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.10",
         "fflate": "^0.8.2",
@@ -1190,7 +1188,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1382,7 +1379,6 @@
       "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -1424,7 +1420,6 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -1500,7 +1495,6 @@
       "integrity": "sha512-2Fqty3MM9CDwOVet/jaQalYlbcjATZwPYGcqpiYQqgQ/dLC7GuHdISKgTYIVF/kaishKxLzleKWWfbSDklyIKg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.10",
         "@vitest/mocker": "4.0.10",


### PR DESCRIPTION
## Summary

- Replaced all source color values in  with the official [Tailwind CSS color palette](https://tailwindcss.com/docs/colors) hex values
- Updated semantic tokens (destructive, success, warning, info) to map to their Tailwind equivalents (red-500, green-500, amber-500, blue-500)
- Updated all named palette colors (red, orange, amber, yellow, lime, green, emerald, teal, cyan, sky, blue, indigo, violet, purple, fuchsia, pink, rose) to use Tailwind's standard 500-level hues

## Test plan

- [ ] Verify token values in Figma Tokens plugin match the new Tailwind CSS color values
- [ ] Check that semantic color tokens (destructive, success, warning, info) render correctly in UI components
- [ ] Confirm all color names in the palette resolve to their correct Tailwind equivalents visually
- [ ] Run any existing token build/export scripts to ensure no schema errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)