### PR TITLE
Add primary/secondary color tokens for dark and light themes

### DIFF
--- a/figma-tokens/$tokens.json
+++ b/figma-tokens/$tokens.json
@@ -16,11 +16,11 @@
             "type": "color"
           },
           "secondary-light": {
-            "value": "#dfe7e3",
+            "value": "#e5e5e5",
             "type": "color"
           },
           "secondary-dark": {
-            "value": "#26262b",
+            "value": "#262626",
             "type": "color"
           },
           "destructive": {
@@ -247,11 +247,11 @@
         "light": {
           "color": {
             "primary": {
-              "value": "{ivy-framework.source.color.primary}",
+              "value": "{ivy-framework.source.color.black}",
               "type": "color"
             },
             "primary-foreground": {
-              "value": "{ivy-framework.source.color.black}",
+              "value": "{ivy-framework.source.color.white}",
               "type": "color"
             },
             "secondary": {
@@ -351,7 +351,7 @@
         "dark": {
           "color": {
             "primary": {
-              "value": "{ivy-framework.source.color.primary}",
+              "value": "{ivy-framework.source.color.white}",
               "type": "color"
             },
             "primary-foreground": {


### PR DESCRIPTION
## Summary

- Added a  color token to : white for dark theme, black for light theme (replacing the previous green value)
- Added a  color token as a lighter/darker variant of the primary color
- All non-source-color token values reference colors from the  array, following the established convention

## Test plan

- [ ] Verify the dark theme renders  as white and  as an appropriate lighter/darker variant
- [ ] Verify the light theme renders  as black and  as an appropriate lighter/darker variant
- [ ] Confirm no hardcoded color values are used — all tokens reference entries from the source colors array
- [ ] Check that existing components using color tokens still render correctly in both themes
