### PR TITLE
fix: invert foreground colors for chromatic tokens

### DIFF
--- a/figma-tokens/$tokens.json
+++ b/figma-tokens/$tokens.json
@@ -580,7 +580,7 @@
             "type": "color"
           },
           "teal-foreground": {
-            "value": "{ivy-framework.source.color.white}",
+            "value": "{ivy-framework.source.color.black}",
             "type": "color"
           },
           "cyan": {
@@ -588,7 +588,7 @@
             "type": "color"
           },
           "cyan-foreground": {
-            "value": "{ivy-framework.source.color.white}",
+            "value": "{ivy-framework.source.color.black}",
             "type": "color"
           },
           "sky": {
@@ -596,7 +596,7 @@
             "type": "color"
           },
           "sky-foreground": {
-            "value": "{ivy-framework.source.color.white}",
+            "value": "{ivy-framework.source.color.black}",
             "type": "color"
           },
           "blue": {
@@ -604,7 +604,7 @@
             "type": "color"
           },
           "blue-foreground": {
-            "value": "{ivy-framework.source.color.white}",
+            "value": "{ivy-framework.source.color.black}",
             "type": "color"
           },
           "indigo": {
@@ -612,7 +612,7 @@
             "type": "color"
           },
           "indigo-foreground": {
-            "value": "{ivy-framework.source.color.white}",
+            "value": "{ivy-framework.source.color.black}",
             "type": "color"
           },
           "violet": {
@@ -620,7 +620,7 @@
             "type": "color"
           },
           "violet-foreground": {
-            "value": "{ivy-framework.source.color.white}",
+            "value": "{ivy-framework.source.color.black}",
             "type": "color"
           },
           "purple": {
@@ -628,7 +628,7 @@
             "type": "color"
           },
           "purple-foreground": {
-            "value": "{ivy-framework.source.color.white}",
+            "value": "{ivy-framework.source.color.black}",
             "type": "color"
           },
           "fuchsia": {
@@ -636,7 +636,7 @@
             "type": "color"
           },
           "fuchsia-foreground": {
-            "value": "{ivy-framework.source.color.black}",
+            "value": "{ivy-framework.source.color.white}",
             "type": "color"
           },
           "pink": {
@@ -644,7 +644,7 @@
             "type": "color"
           },
           "pink-foreground": {
-            "value": "{ivy-framework.source.color.black}",
+            "value": "{ivy-framework.source.color.white}",
             "type": "color"
           },
           "rose": {
@@ -652,7 +652,7 @@
             "type": "color"
           },
           "rose-foreground": {
-            "value": "{ivy-framework.source.color.black}",
+            "value": "{ivy-framework.source.color.white}",
             "type": "color"
           }
         }


### PR DESCRIPTION
## Summary
- Inverted foreground colors for teal, cyan, sky, blue, indigo, violet, purple from white → black
- Inverted foreground colors for fuchsia, pink, rose from black → white

## Test plan
- [ ] Verify badge/chip contrast is correct for all affected colors in the demo app
- [ ] Confirm build passes with updated tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)