### PR TITLE
[01166] Change token.json popover colors in dark theme to card-dark

### DIFF
--- a/figma-tokens/$tokens.json
+++ b/figma-tokens/$tokens.json
@@ -447,7 +447,7 @@
               "type": "color"
             },
             "popover": {
-              "value": "{ivy-framework.source.color.black}",
+              "value": "{ivy-framework.source.color.card-dark}",
               "type": "color"
             },
             "popover-foreground": {


### PR DESCRIPTION
# Summary

## Changes

Changed the dark theme `color.popover` token from `{ivy-framework.source.color.black}` (#000000) to `{ivy-framework.source.color.card-dark}` (#171717). This aligns popover backgrounds with card backgrounds in dark mode, providing a consistent elevated surface color instead of pure black.

## API Changes

- `--color-popover` CSS variable in dark theme: `#000000` -> `#171717`
- `IvyFrameworkDarkThemeTokens.Popover` C# property: `"#000000"` -> `"#171717"`

## Files Modified

- `figma-tokens/$tokens.json` — Updated dark theme popover color reference

## Commits

- 8bb3550 [01166] Change dark theme popover color from black to card-dark