### PR TITLE
[01485] Add --border-secondary color token to light and dark themes

### DIFF
--- a/figma-tokens/$tokens.json
+++ b/figma-tokens/$tokens.json
@@ -613,6 +613,10 @@
               "value": "{ivy-framework.source.color.border}",
               "type": "color"
             },
+            "border-secondary": {
+              "value": "{ivy-framework.source.color.border-secondary}",
+              "type": "color"
+            },
             "input": {
               "value": "{ivy-framework.source.color.border}",
               "type": "color"
@@ -715,6 +719,10 @@
             },
             "border": {
               "value": "{ivy-framework.source.color.card-foreground-light}",
+              "type": "color"
+            },
+            "border-secondary": {
+              "value": "{ivy-framework.source.color.border-secondary}",
               "type": "color"
             },
             "input": {


### PR DESCRIPTION
## Changes

Added `border-secondary` color token references to both light and dark theme sections in `figma-tokens/$tokens.json`. Both themes reference the existing source token `{ivy-framework.source.color.border-secondary}` which resolves to `#3c3c3c`.

## API Changes

- New CSS custom property: `--color-border-secondary` (available in both light and dark themes)

## Files Modified

- `figma-tokens/$tokens.json` -- Added `border-secondary` entry to light theme (line ~616) and dark theme (line ~724)

## Commits

- f416a8d [01485] Add border-secondary token to light and dark themes